### PR TITLE
Adds test cases for simultaneous DGD sections.

### DIFF
--- a/db_test_data.sql
+++ b/db_test_data.sql
@@ -1,6 +1,6 @@
-use feedback;
+--use feedback;
 INSERT INTO course(code)
-VALUES ('ITI1120'),('ITI1121'),('CEG2136');
+VALUES ('ITI1120'), ('ITI1121'), ('CEG2136'), ('ITI1100');
 
 INSERT INTO ta(stnum, firstName, lastName, profilepic) VALUES
 ('1','Ashwin','Pancakes','AuntJemima.logo'),
@@ -9,11 +9,13 @@ INSERT INTO ta(stnum, firstName, lastName, profilepic) VALUES
 ('4','Remi','Gel','Rems.png');
 
 INSERT INTO section(course, sectionID,currYear,semester, weekday, startTime, endTime) VALUES
-('ITI1120', 'T1',2016,1, '1', '11:30', '14:30'),
-('CEG2136', 'T1',2016,1, '1', '11:30', '14:30'),
-('ITI1120', 'T2',2016,1, '2', '14:30', '17:30'),
-('ITI1121', 'T1',2017,2, '1', '11:30', '14:30'),
-('ITI1121', 'T2',2017,2, '2', '14:30', '17:30');
+('ITI1120', 'T1', 2016, 1, '1', '11:30', '14:30'),
+('CEG2136', 'T1', 2016, 1, '1', '11:30', '14:30'),
+('ITI1120', 'T2', 2016, 1, '2', '14:30', '17:30'),
+('ITI1121', 'T1', 2017, 2, '1', '11:30', '14:30'),
+('ITI1121', 'T2', 2017, 2, '2', '14:30', '17:30'),
+('ITI1100', 'T1', 2017, 2, '3', '8:30', '10:00'),
+('ITI1100', 'T2', 2017, 2, '3', '8:30', '10:00');
 
 
 INSERT INTO teaches(taID, course, section, currYear, semester) VALUES
@@ -22,4 +24,6 @@ INSERT INTO teaches(taID, course, section, currYear, semester) VALUES
 ('4', 'CEG2136', 'T1', '2016', '1'),
 ('2', 'ITI1120', 'T2', '2016', '1'),
 ('1', 'ITI1121', 'T2', '2017', '2'),
-('3', 'ITI1121', 'T1', '2017', '2');
+('3', 'ITI1121', 'T1', '2017', '2'),
+('3', 'ITI1100', 'T1', '2017', '2'),
+('4', 'ITI1100', 'T2', '2017', '2');


### PR DESCRIPTION
As described in #34 and separately in #41, this adds edge cases to
`db_test_data.sql` where DGDs occur simultaneously with distinct
sections, TAs, and (implicitly) locations.

Causes expected behaviour and no unexpected side-effects; tentatively
closes #34 and #41 pending review.

`use-feedback` in `db_test_data.sql:1` was found to be superfluous in common use cases, but may be preserved for cases where the database name is not the database username (AKA non-default behaviour in PostgreSQL). Please leave a comment saying so if that line should stay in.